### PR TITLE
Move SEO tags into head

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,12 @@
   <meta property="og:image" content="https://kleine-musikschule.de/img/logo_small.png" />
   <meta property="og:url" content="https://kleine-musikschule.de/" />
   <meta property="og:type" content="website" />
-</head>
-<body class="is-preload">
-
-	 <!-- SEO Extras -->
+  <!-- SEO Extras -->
   <meta name="robots" content="index, follow" />
   <meta name="keywords" content="Musikschule Karlsruhe, Musikunterricht Karlsruhe, Gitarre lernen, Klavierunterricht, mobile Musikschule, Musiklehrer privat Karlsruhe, E-Bass Unterricht, Ukulele lernen" />
   <link rel="canonical" href="https://kleine-musikschule.de/" />
 </head>
+<body class="is-preload">
 
 <!-- Wrapper -->
 <div id="wrapper">


### PR DESCRIPTION
## Summary
- move SEO meta tags and canonical link inside the head section
- remove duplicated closing head tag

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c2dffac8321b939d98b2d3c7b10