### PR TITLE
Align sitemap anchors with section IDs

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,12 +1,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <!-- Created manually based on your navigation -->
   <url>
-    <loc>https://kleine-musikschule.de/#</loc>
+    <loc>https://kleine-musikschule.de/</loc>
     <lastmod>2025-01-16T14:40:00+00:00</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://kleine-musikschule.de/#ueber-uns</loc>
+    <loc>https://kleine-musikschule.de/#ueber_uns</loc>
     <lastmod>2025-01-16T14:40:00+00:00</lastmod>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary
- fix `sitemap.xml` anchors to match `index.html` IDs
- ensure root page is referenced without a stray `#`

## Testing
- ⚠️ `xmllint --noout sitemap.xml` *(command not found; `apt-get update` failed with 403)*
- ✅ `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('sitemap.xml')
print('XML is well-formed')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a21c66094083218deb994bd39d63a5