### PR TITLE
Add alt text for TLS lock icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,9 +648,10 @@
 								Verschlüsselungsprotokoll zur sicheren Datenübertragung im Internet,
 								können wir den Schutz vertraulicher Daten sicherstellen.<br />
 								Sie erkennen die Benutzung dieser Absicherung der Datenübertragung am
-								kleinen Schlosssymbol <img role="img"
-									src="https://www.adsimple.at/wp-content/uploads/2018/03/schlosssymbol-https.svg"
-									width="17" height="18" /> links oben im Browser, links von der
+                                                                kleinen Schlosssymbol <img role="img"
+                                                                        src="https://www.adsimple.at/wp-content/uploads/2018/03/schlosssymbol-https.svg"
+                                                                        alt="TLS-Verschlüsselung Symbol"
+                                                                        width="17" height="18" /> links oben im Browser, links von der
 								Internetadresse (z. B. beispielseite.de) und der Verwendung des Schemas
 								https (anstatt http) als Teil unserer Internetadresse.<br />
 								Wenn Sie mehr zum Thema Verschlüsselung wissen möchten, empfehlen wir


### PR DESCRIPTION
## Summary
- add descriptive alt text for TLS lock icon image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c66d7148321b9d5f0b9fdf0a4d9