### PR TITLE
Restore musician resource links and polish bios

### DIFF
--- a/ebass.html
+++ b/ebass.html
@@ -59,6 +59,13 @@
         width: 16px;
         height: 16px;
       }
+      .artist-link {
+        margin: 0.2em 0 1.6em;
+        font-size: 0.95em;
+      }
+      .artist-link a {
+        margin-left: 0.5em;
+      }
       .ausruestung-img {
         display: block;
         max-width: 400px;
@@ -139,65 +146,110 @@
         </article>
         <article id="bassisten">
           <h2 class="major">Ikonen am E-Bass: Berühmte Bassisten</h2>
-          <ul>
-            <li>
-              <b>Jaco Pastorius</b> – Revolutionierte den Jazz-Bass mit seinem
-              Fretless-Spiel und komplexen Soli. Sein Sound ist bis heute
-              einzigartig.
-              <a
-                href="https://www.youtube.com/watch?v=QFq5O2kabQo"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Flea</b> (Red Hot Chili Peppers) – Sein energiegeladenes
-              Slap-Spiel und seine Bühnenpräsenz machen ihn zu einem der
-              bekanntesten Rock-Bassisten.
-              <a
-                href="https://www.youtube.com/watch?v=YlUKcNNmywk"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Marcus Miller</b> – Meister des Funk und Jazz, bekannt für
-              seinen Groove und seine Vielseitigkeit als Musiker und Produzent.
-              <a
-                href="https://www.youtube.com/watch?v=3jvQ_TJrF_E"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Paul McCartney</b> (The Beatles) – Als Songwriter und Bassist
-              prägte er den Sound der Beatles und beeinflusste Generationen.
-              <a
-                href="https://www.youtube.com/watch?v=NCtzkaL2t_Y"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Carol Kaye</b> – Studio-Legende, spielte auf hunderten Hits und
-              prägte den Bass-Sound der 60er und 70er Jahre.
-              <a
-                href="https://www.youtube.com/watch?v=Qe6pHh7bKjI"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-          </ul>
+          <p>
+            Ob Jazz, Rock oder Funk – diese Bassistinnen und Bassisten zeigen,
+            wie vielfältig das Fundament einer Band klingen kann.
+          </p>
+          <h3>Jaco Pastorius (1951-1987)</h3>
+          <p>
+            Der in Florida geborene Jaco Pastorius wechselte nach einer
+            Handverletzung vom Schlagzeug zum Bass und stieg mit Anfang zwanzig
+            bei Weather Report ein. Mit singenden Flageoletts, Walking Lines und
+            Improvisationen auf Weltniveau machte er den Fretless-Bass zum
+            Soloinstrument – inklusive des legendären Fender Jazz Bass, dem er
+            eigenhändig die Bundstäbe zog und dessen Griffbrett er mit
+            Epoxidharz versiegelte.
+          </p>
+          <p class="artist-link">
+            Hör dir seinen Klassiker „Portrait of Tracy“ an:
+            <a
+              href="https://www.youtube.com/watch?v=QFq5O2kabQo"
+              target="_blank"
+              class="ug-link"
+              aria-label="Jaco Pastorius auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Flea (geb. 1962)</h3>
+          <p>
+            Michael „Flea“ Balzary zog als Kind von Australien nach Los Angeles,
+            wo ihn sein jazzspielender Stiefvater musikalisch prägte. Mit seinem
+            Schulfreund Anthony Kiedis gründete er die Red Hot Chili Peppers,
+            deren energiegeladener Mix aus Funk und Punk ihn weltweit bekannt
+            machte – daneben engagiert er sich mit dem Silverlake Music
+            Conservatory für Nachwuchs und steht immer wieder als Schauspieler
+            vor der Kamera.
+          </p>
+          <p class="artist-link">
+            Hörprobe: Red Hot Chili Peppers live bei „Give It Away“
+            <a
+              href="https://www.youtube.com/watch?v=YlUKcNNmywk"
+              target="_blank"
+              class="ug-link"
+              aria-label="Flea auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Marcus Miller (geb. 1959)</h3>
+          <p>
+            Marcus Miller wuchs in Brooklyn in einer Musikerfamilie auf und war
+            bereits mit 15 Jahren als Studioprofi gefragt. Als Komponist,
+            Produzent und Multiinstrumentalist schrieb er u.&nbsp;a. den
+            Titeltrack für Miles Davis’ Album „Tutu“, gewann mehrere Grammys und
+            kombiniert bis heute Funk, Jazz und Soul mit eigener Klarinette oder
+            programmierten Synth-Sounds.
+          </p>
+          <p class="artist-link">
+            Sein Groove in „Detroit“ live erleben:
+            <a
+              href="https://www.youtube.com/watch?v=3jvQ_TJrF_E"
+              target="_blank"
+              class="ug-link"
+              aria-label="Marcus Miller auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Paul McCartney (geb. 1942)</h3>
+          <p>
+            Paul McCartney aus Liverpool prägte mit melodischen Basslinien den
+            Sound der Beatles, nachdem er das Instrument notgedrungen übernahm.
+            Nach der Band gründete er Wings, schrieb unzählige Hits, komponierte
+            Orchesterwerke und engagiert sich bis heute für Tierschutz und
+            Bildung.
+          </p>
+          <p class="artist-link">
+            Legendärer Höfner-Sound in „Paperback Writer“:
+            <a
+              href="https://www.youtube.com/watch?v=NCtzkaL2t_Y"
+              target="_blank"
+              class="ug-link"
+              aria-label="Paul McCartney auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Carol Kaye (geb. 1935)</h3>
+          <p>
+            Carol Kaye begann als Jazz-Gitarristin in Los Angeles und avancierte
+            als Mitglied der „Wrecking Crew“ zur meistgebuchten Studiobassistin
+            der 1960er Jahre. Sie spielte auf Hunderten von Hits, von den Beach
+            Boys bis zu den Monkees, bevorzugte Plektren für ihren präzisen
+            Attack und veröffentlichte einflussreiche Lehrmaterialien.
+          </p>
+          <p class="artist-link">
+            Studiomagie bei „Good Vibrations“:
+            <a
+              href="https://www.youtube.com/watch?v=Qe6pHh7bKjI"
+              target="_blank"
+              class="ug-link"
+              aria-label="Carol Kaye auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
         </article>
         <article id="songs">
           <h2 class="major">Songs & Grooves zum Lernen</h2>

--- a/gitarre.html
+++ b/gitarre.html
@@ -181,51 +181,61 @@
 
           <h3>Jimi Hendrix (1942-1970)</h3>
           <p>
-            Ein absoluter Pionier der E-Gitarre. Hendrix revolutionierte das
-            Spiel mit Verzerrung, Feedback und Effekten. Seine Performance beim
-            Monterey Pop Festival (1967) und Woodstock (1969) sind legendär. Er
-            machte die Gitarre zu einer Erweiterung seiner selbst und seine
-            Musik beeinflusst bis heute unzählige Künstler.
+            Jimi Hendrix wuchs in Seattle in bescheidenen Verhältnissen auf und
+            fand schon als Teenager in der Gitarre seinen Zufluchtsort. Nach
+            seiner Zeit bei der 101st Airborne tourte er mit Rhythm-&-Blues-Bands
+            durch die USA, bevor ihn Chas Chandler 1966 nach London holte, wo er
+            mit Feedback, Wah-Wah und Studioexperimenten die Rockmusik
+            revolutionierte – meist auf einer auf links gedrehten
+            Rechtshänder-Stratocaster, die er einen Halbton tiefer stimmte und
+            bei Shows auch mal in Flammen setzte.
           </p>
           <h3>Eric Clapton (geb. 1945)</h3>
           <p>
-            Bekannt als "Slowhand", hat Clapton den Blues-Rock geprägt wie kaum
-            ein anderer. Von seinen Anfängen bei The Yardbirds und Cream bis zu
-            seiner Solo-Karriere zeigte er, wie gefühlvoll und virtuos man den
-            Blues interpretieren kann. Seine Fähigkeit, mit wenigen Noten so
-            viel auszudrücken, ist bewundernswert.
+            Eric Clapton wurde in Surrey von seinen Großeltern großgezogen und
+            arbeitete sich von den Yardbirds über Cream bis zur Solokarriere zum
+            Aushängeschild des britischen Bluesrock hoch. Nach öffentlich
+            geführten Kämpfen gegen seine Sucht engagiert er sich heute für
+            Therapie- und Reha-Projekte – und sein Spitzname „Slowhand“ erinnert
+            daran, wie geduldig das Publikum seine ausgedehnten Saitenwechsel
+            beklatschte.
           </p>
           <h3>B.B. King (1925-2015)</h3>
           <p>
-            Der "King of the Blues". B.B. King's einzigartiger Stil, sein
-            vibrato und sein unverwechselbarer Klang, den er seiner Gitarre
-            "Lucille" entlockte, machten ihn zu einer Legende. Er beeinflusste
-            Generationen von Blues- und Rockgitarristen und gilt als einer der
-            wichtigsten Musiker des 20. Jahrhunderts.
+            Riley B. „B.B.“ King arbeitete als Jugendlicher auf Baumwollfeldern
+            in Mississippi, bevor er als Radiomoderator nach Memphis ging und
+            dort den modernen Blues maßgeblich mitgestaltete. Mehr als 15.000
+            Konzerte machten ihn zum Botschafter des Genres und zu einer
+            stilprägenden Stimme für Generationen von Gitarristen – seine
+            Gitarre taufte er nach einem Tanzsaalbrand „Lucille“ und ließ ihr von
+            Gibson eigene Signature-Modelle widmen.
           </p>
           <h3>Jimmy Page (geb. 1944)</h3>
           <p>
-            Als Mastermind und Gitarrist von Led Zeppelin schuf Jimmy Page
-            einige der ikonischsten Riffs der Rockgeschichte. Sein innovativer
-            Einsatz von Gitarrenharmonien, Open Tunings und seine Fähigkeit,
-            Blues, Folk und Hard Rock zu verschmelzen, machten Led Zeppelin zu
-            einer der größten Bands aller Zeiten.
+            Jimmy Page war schon als Teenager gefragter Studiomusiker und
+            gründete nach den Yardbirds Led Zeppelin, deren Sound er als
+            Produzent, Songwriter und Gitarrist formte. Seine Mischung aus Blues,
+            Folk und Hardrock sowie sein Gespür für Dramaturgie machten die Band
+            zu einer Ikone der 1970er Jahre – gelegentlich setzte er auf der
+            Bühne sogar einen Geigenbogen ein und pflegte eine Vorliebe für
+            okkulte Literatur.
           </p>
           <h3>Eddie Van Halen (1955-2020)</h3>
           <p>
-            Van Halen veränderte das Spiel der E-Gitarre in den späten 70er und
-            80er Jahren. Seine Technik des "Two-Hand Tapping" und sein
-            aggressiver, aber melodischer Stil setzten neue Maßstäbe für
-            Virtuosität und Sound. Songs wie "Eruption" sind Lehrstücke in
-            Gitarrenakrobatik.
+            Eddie Van Halen zog als Kind von den Niederlanden nach Kalifornien,
+            lernte zunächst Klavier und fand dann mit seinem Bruder Alex zur
+            Gitarre. Mit Van Halen brachte er in den späten 1970ern eine neue,
+            spektakuläre Virtuosität in den Rock, tüftelte an seiner
+            selbstgebauten „Frankenstrat“ und blieb trotz gesundheitlicher
+            Rückschläge bis zuletzt kreativ.
           </p>
           <h3>Mark Knopfler (geb. 1949)</h3>
           <p>
-            Der Dire Straits-Frontmann ist bekannt für seinen unverwechselbaren
-            "Fingerpicking"-Stil, bei dem er ohne Plektrum spielt. Sein
-            präzises, melodiöses und oft minimalistisches Spiel, kombiniert mit
-            seiner markanten Stimme, schuf einen einzigartigen Sound, der ihn zu
-            einem der meistrespektierten Gitarristen macht.
+            Mark Knopfler wurde in Schottland geboren, wuchs im Norden Englands
+            auf und arbeitete als Journalist und Lehrer, bevor Dire Straits mit
+            „Sultans of Swing“ durchstarteten. Seither verbindet er lässiges
+            Storytelling mit subtilem Spiel, formt seinen warmen Ton ganz ohne
+            Plektrum und komponiert regelmäßig Filmmusik.
           </p>
         </article>
 

--- a/klavier.html
+++ b/klavier.html
@@ -159,22 +159,53 @@
         </article>
         <article id="pianisten">
           <h2 class="major">Berühmte Pianisten</h2>
-          <ul>
-            <li><b>Ludwig van Beethoven</b> – Komponist und Klaviervirtuose</li>
-            <li>
-              <b>Frédéric Chopin</b> – Meister der romantischen Klaviermusik
-            </li>
-            <li><b>Lang Lang</b> – Moderner Starpianist</li>
-            <li><b>Elton John</b> – Pop-Ikone und Songwriter</li>
-            <li><b>Alicia Keys</b> – R&B und Soul</li>
-          </ul>
           <p>
-            Hier findest du
-            <a
-              href="https://www.youtube.com/results?search_query=piano+virtuoso"
-              target="_blank"
-              >YouTube-Videos von Pianisten</a
-            >.
+            Diese Pianistinnen und Pianisten zeigen, wie unterschiedlich ein
+            Leben mit Tasten verlaufen kann – von Klassik bis Pop.
+          </p>
+          <h3>Ludwig van Beethoven (1770-1827)</h3>
+          <p>
+            Beethoven kam in Bonn zur Welt, zog als junger Virtuose nach Wien
+            und begeisterte dort mit improvisierten Klavierduellen. Trotz
+            fortschreitender Taubheit komponierte er einige der emotionalsten
+            Werke der Musikgeschichte, prägte den Übergang zur Romantik und
+            zelebrierte jeden Tag seine 60 sorgfältig gezählten Kaffeebohnen.
+          </p>
+          <h3>Frédéric Chopin (1810-1849)</h3>
+          <p>
+            Der Pole Frédéric Chopin verließ Warschau nach dem gescheiterten
+            Novemberaufstand und fand in Paris ein künstlerisches Zuhause. Er
+            komponierte fast ausschließlich für Klavier, gab elegante
+            Salonkonzerte, pflegte eine intensive Beziehung zur Schriftstellerin
+            George Sand und schwor auf die feinen Pleyel-Flügel, die seiner
+            Meinung nach seine Gedanken erahnten.
+          </p>
+          <h3>Lang Lang (geb. 1982)</h3>
+          <p>
+            Lang Lang wuchs im chinesischen Shenyang auf, sein Vater begleitete
+            ihn für die Ausbildung nach Peking, wo sie in einer kleinen Wohnung
+            ohne Heizung lebten. Mit 17 sprang er beim Ravinia Festival ein,
+            wurde über Nacht zum internationalen Star und ließ sich von einer
+            „Tom &amp; Jerry“-Folge inspirieren, später selbst eine Stiftung für
+            Musikbildung zu gründen.
+          </p>
+          <h3>Elton John (geb. 1947)</h3>
+          <p>
+            Sir Elton John, geboren als Reginald Dwight, erhielt ein Stipendium
+            an der Royal Academy of Music und schrieb zusammen mit Bernie Taupin
+            über 300 Songs. Nach Jahren der Exzesse nutzt er seinen Ruhm für die
+            Elton John AIDS Foundation – und besitzt so viele extravagante
+            Bühnenbrillen, dass sie ein eigenes Archiv füllen.
+          </p>
+          <h3>Alicia Keys (geb. 1981)</h3>
+          <p>
+            Alicia Keys wuchs in Manhattan bei ihrer Mutter auf, erhielt ein
+            Stipendium an der Professional Performing Arts School und unterschrieb
+            mit 15 ihren ersten Plattenvertrag. Ihr Debüt „Songs in A Minor“
+            machte sie zur mehrfachen Grammy-Gewinnerin und zu einer wichtigen
+            Stimme für soziale Themen – sie schloss die Highschool ein Jahr
+            früher ab und gründete „She Is The Music“, um mehr Frauen in die
+            Musikproduktion zu bringen.
           </p>
         </article>
         <article id="stuecke">

--- a/schlagzeug.html
+++ b/schlagzeug.html
@@ -62,6 +62,13 @@
         width: 16px;
         height: 16px;
       }
+      .artist-link {
+        margin: 0.2em 0 1.6em;
+        font-size: 0.95em;
+      }
+      .artist-link a {
+        margin-left: 0.5em;
+      }
       .ausruestung-img {
         display: block;
         max-width: 400px;
@@ -125,68 +132,105 @@
         </article>
         <article id="drummer">
           <h2 class="major">Ikonen am Schlagzeug: Berühmte Drummer</h2>
-          <ul>
-            <li>
-              <b>John Bonham</b> (Led Zeppelin) – Mit seinem kraftvollen und
-              kreativen Spiel prägte er den Rock-Sound der 70er. Sein Solo in
-              „Moby Dick“ ist legendär.
-              <a
-                href="https://www.youtube.com/watch?v=2cZ_EFAmj08"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Buddy Rich</b> – Gilt als einer der technisch besten
-              Jazz-Drummer aller Zeiten. Seine Geschwindigkeit und Präzision
-              sind bis heute unerreicht.
-              <a
-                href="https://www.youtube.com/watch?v=3Avb6y2l8F0"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Sheila E.</b> – Als Percussionistin und Drummerin begeistert
-              sie mit energiegeladenen Soli und ist ein Vorbild für viele junge
-              Musikerinnen.
-              <a
-                href="https://www.youtube.com/watch?v=QYHxGBH6o4M"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Ringo Starr</b> (The Beatles) – Sein minimalistischer Stil und
-              sein musikalisches Gespür machten ihn zu einem der
-              einflussreichsten Pop-Drummer.
-              <a
-                href="https://www.youtube.com/watch?v=6k8es2BNloM"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Travis Barker</b> (Blink-182) – Mit schnellen Beats und
-              kreativen Fills ist er einer der bekanntesten Drummer der modernen
-              Punk- und Pop-Szene.
-              <a
-                href="https://www.youtube.com/watch?v=3g5Rkjc5YzI"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-          </ul>
+          <p>
+            Von Rock bis Jazz – diese Schlagzeugerinnen und Schlagzeuger zeigen,
+            wie sehr Persönlichkeit und Groove den Bandsound prägen.
+          </p>
+          <h3>John Bonham (1948-1980)</h3>
+          <p>
+            John Bonham aus den englischen Midlands trommelte als Kind auf
+            Töpfen, arbeitete kurz als Maurer und wurde dann das Herz von Led
+            Zeppelin. Seine gewaltige Bassdrum und sein Gefühl für Dynamik
+            definierten den Hardrock der 1970er Jahre – und bei Soli wie „Moby
+            Dick“ griff er schon mal mit bloßen Händen an die Felle.
+          </p>
+          <p class="artist-link">
+            Bonhams Drumsolo live 1970:
+            <a
+              href="https://www.youtube.com/watch?v=2cZ_EFAmj08"
+              target="_blank"
+              class="ug-link"
+              aria-label="John Bonham auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Buddy Rich (1917-1987)</h3>
+          <p>
+            Buddy Rich war ein Wunderkind des Vaudeville, diente im Zweiten
+            Weltkrieg und leitete später eigene Big Bands. Seine unglaubliche
+            Technik machte ihn zur Messlatte für Jazz-Drummer auf der ganzen
+            Welt, obwohl er komplexe Arrangements meist schlicht nach Gehör
+            spielte.
+          </p>
+          <p class="artist-link">
+            TV-Auftritt bei der Tonight Show:
+            <a
+              href="https://www.youtube.com/watch?v=3Avb6y2l8F0"
+              target="_blank"
+              class="ug-link"
+              aria-label="Buddy Rich auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Sheila E. (geb. 1957)</h3>
+          <p>
+            Sheila Escovedo stammt aus einer Musikerfamilie in Kalifornien und
+            stand schon mit fünf Jahren mit ihrem Vater Pete auf der Bühne. Mit
+            Prince ging sie in den 1980ern auf Welttournee und verbindet seither
+            Latin-Grooves mit Pop-Energie, während ihre Elevate Hope Foundation
+            benachteiligte Kinder unterstützt.
+          </p>
+          <p class="artist-link">
+            Timbales-Show mit Prince:
+            <a
+              href="https://www.youtube.com/watch?v=QYHxGBH6o4M"
+              target="_blank"
+              class="ug-link"
+              aria-label="Sheila E. auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Ringo Starr (geb. 1940)</h3>
+          <p>
+            Ringo Starr verbrachte als Kind viel Zeit im Krankenhaus, fand aber
+            in der Musik neue Energie. Als Beatle lieferte er mit lässigem Groove
+            und Humor den Puls für die Band, tourt bis heute mit seiner All-Starr
+            Band und nutzt trotz Linkshändigkeit ein Rechtshänder-Set – was seine
+            berühmten „um die Ecke“-Fills ermöglicht.
+          </p>
+          <p class="artist-link">
+            Beatles-Groove zu „Come Together“:
+            <a
+              href="https://www.youtube.com/watch?v=6k8es2BNloM"
+              target="_blank"
+              class="ug-link"
+              aria-label="Ringo Starr auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Travis Barker (geb. 1975)</h3>
+          <p>
+            Travis Barker wuchs in Südkalifornien auf, spielte in Marching Bands
+            und wurde mit Blink-182 zum Aushängeschild des Pop-Punk. Nach einem
+            Flugzeugabsturz 2008 kämpfte er sich zurück auf die Bühne, mischt mit
+            Kollaborationen von Punk bis Hip-Hop und betreibt nebenbei die
+            Streetwear-Marke „Famous Stars and Straps“.
+          </p>
+          <p class="artist-link">
+            Drum-&-DJ-Performance mit Travis Barker:
+            <a
+              href="https://www.youtube.com/watch?v=3g5Rkjc5YzI"
+              target="_blank"
+              class="ug-link"
+              aria-label="Travis Barker auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
         </article>
         <article id="songs">
           <h2 class="major">Songs & Grooves zum Lernen</h2>

--- a/ukulele.html
+++ b/ukulele.html
@@ -59,6 +59,13 @@
         width: 16px;
         height: 16px;
       }
+      .artist-link {
+        margin: 0.2em 0 1.6em;
+        font-size: 0.95em;
+      }
+      .artist-link a {
+        margin-left: 0.5em;
+      }
       .ausruestung-img {
         display: block;
         max-width: 400px;
@@ -138,64 +145,105 @@
         </article>
         <article id="spieler">
           <h2 class="major">Ikonen der Ukulele: Berühmte Spieler</h2>
-          <ul>
-            <li>
-              <b>Israel Kamakawiwoʻole</b> – Mit seinem gefühlvollen Medley aus
-              „Somewhere Over the Rainbow/What a Wonderful World“ machte er die
-              Ukulele weltweit bekannt.
-              <a
-                href="https://www.youtube.com/watch?v=V1bFr2SWP1I"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Jake Shimabukuro</b> – Gilt als „Jimi Hendrix der Ukulele“ und
-              begeistert mit virtuosen Techniken und modernen Interpretationen.
-              <a
-                href="https://www.youtube.com/watch?v=snPQ1z5FoqQ"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Grace VanderWaal</b> – Wurde mit der Ukulele bei „America’s Got
-              Talent“ berühmt und inspiriert viele junge Musiker.
-              <a
-                href="https://www.youtube.com/watch?v=EvsfUQwF6yE"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Eddie Vedder</b> – Der Pearl Jam-Sänger veröffentlichte ein
-              ganzes Ukulele-Album und zeigt die Vielseitigkeit des Instruments.
-              <a
-                href="https://www.youtube.com/watch?v=Qh4V9p2ZpEY"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-            <li>
-              <b>Billie Eilish</b> – Nutzt die Ukulele für viele ihrer Songs und
-              bringt sie in die moderne Popmusik.
-              <a
-                href="https://www.youtube.com/watch?v=pbMwTqkKSps"
-                target="_blank"
-                class="ug-link"
-              >
-                <img src="img/open_in_new.png" alt="YouTube-Link" />
-              </a>
-            </li>
-          </ul>
+          <p>
+            Von Hawaii bis Hollywood – diese Künstler zeigen, wie vielseitig die
+            kleine Vier-Saiterin sein kann.
+          </p>
+          <h3>Israel Kamakawiwoʻole (1959-1997)</h3>
+          <p>
+            „IZ“ wurde in Honolulu geboren, gründete die Makaha Sons of Niʻihau
+            und setzte sich sein Leben lang für hawaiianische Kultur und
+            Eigenständigkeit ein. Seine warme Stimme und minimalistische
+            Begleitung machten ihn zum Symbol für Aloha-Spirit – sein berühmtes
+            Medley „Somewhere Over the Rainbow/What a Wonderful World“ nahm er
+            nachts im Studio in nur einem Take auf.
+          </p>
+          <p class="artist-link">
+            Hör dir das legendäre Medley an:
+            <a
+              href="https://www.youtube.com/watch?v=V1bFr2SWP1I"
+              target="_blank"
+              class="ug-link"
+              aria-label="Israel Kamakawiwoʻole auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Jake Shimabukuro (geb. 1976)</h3>
+          <p>
+            Jake Shimabukuro lernte mit vier Jahren Ukulele, kombiniert Jazz,
+            Rock und Klassik und tourt mittlerweile weltweit. Nach seinem viral
+            gegangenen YouTube-Clip zu „While My Guitar Gently Weeps“ wurde er zu
+            einem der wichtigsten Botschafter des Instruments und spielt sogar
+            für US-Truppen und im Weißen Haus.
+          </p>
+          <p class="artist-link">
+            Virtuose Interpretation von „While My Guitar Gently Weeps“:
+            <a
+              href="https://www.youtube.com/watch?v=snPQ1z5FoqQ"
+              target="_blank"
+              class="ug-link"
+              aria-label="Jake Shimabukuro auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Grace VanderWaal (geb. 2004)</h3>
+          <p>
+            Grace VanderWaal zog als Kind nach New York, schrieb eigene Songs und
+            gewann mit zwölf Jahren „America’s Got Talent“. Seitdem veröffentlicht
+            sie Alben, spielt Konzerte, ermutigt junge Fans, ihre Stimmen zu
+            finden und gestaltet ihre Ukulelen gern selbst mit handgemalten
+            Designs.
+          </p>
+          <p class="artist-link">
+            Ihr Gewinner-Auftritt mit „I Don’t Know My Name“:
+            <a
+              href="https://www.youtube.com/watch?v=EvsfUQwF6yE"
+              target="_blank"
+              class="ug-link"
+              aria-label="Grace VanderWaal auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Eddie Vedder (geb. 1964)</h3>
+          <p>
+            Der Pearl-Jam-Sänger sammelte bereits als Teenager alte Ukulelen und
+            schreibt bis heute intime Songs darauf. Sein Album „Ukulele Songs“
+            zeigt, wie tiefgründig das Instrument klingen kann, und unterwegs
+            tauscht er seltene Vintage-Modelle gern mit Fans.
+          </p>
+          <p class="artist-link">
+            Live-Version von „Can’t Keep“ auf der Ukulele:
+            <a
+              href="https://www.youtube.com/watch?v=Qh4V9p2ZpEY"
+              target="_blank"
+              class="ug-link"
+              aria-label="Eddie Vedder auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
+          <h3>Billie Eilish (geb. 2001)</h3>
+          <p>
+            Billie Eilish wuchs in Los Angeles in einer Künstlerfamilie auf und
+            wurde gemeinsam mit ihrem Bruder Finneas zuhause unterrichtet. Ihre
+            ersten Songs schrieb sie auf der Ukulele, bevor sie weltweit die
+            Charts eroberte – ihr Hit „Ocean Eyes“ startete als Ukulele-Demo im
+            Kinderzimmer.
+          </p>
+          <p class="artist-link">
+            Die frühe „Ocean Eyes“-Version hören:
+            <a
+              href="https://www.youtube.com/watch?v=pbMwTqkKSps"
+              target="_blank"
+              class="ug-link"
+              aria-label="Billie Eilish auf YouTube"
+            >
+              <img src="img/open_in_new.png" alt="YouTube-Link öffnen" />
+            </a>
+          </p>
         </article>
         <article id="songs">
           <h2 class="major">Songs & Licks zum Lernen</h2>


### PR DESCRIPTION
## Summary
- restore per-artist external links on the bass, drum, and ukulele pages with light styling updates
- integrate the fun biographical details directly into the guitarist and pianist write-ups for a smoother tone

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c86130a0f883219c99c6defc853c9d